### PR TITLE
Eval Phase Timeout Timer only starts when two or more players are ready

### DIFF
--- a/Dixit/Assets/Scripts/GameManager.cs
+++ b/Dixit/Assets/Scripts/GameManager.cs
@@ -287,6 +287,16 @@ public class GameManager : NetworkBehaviour
             }
         }
     }
+    private IEnumerator CheckScoreTimerStart()
+    {
+        while (playersReady < 2)
+        { 
+            yield return new WaitForSeconds(1f);
+        }
+        StartCoroutine(CheckEarlyTimeout(Phase.Evaluation));
+        timer.StartTimer(timerToCheckResults, CountdownTimer.timerModes.scoreScreen);
+        
+    }
 
     private void ChooseAnswerPhase()
     {
@@ -384,12 +394,13 @@ public class GameManager : NetworkBehaviour
 
     private IEnumerator WaitAndShowResults()
     {
-        StartCoroutine(CheckEarlyTimeout(Phase.Evaluation));
-        timer.StartTimer(timerToCheckResults, CountdownTimer.timerModes.scoreScreen);
+        StartCoroutine(CheckScoreTimerStart());
         int secs = 3;
         if (answers.Count == 1) secs = 5;
         yield return new WaitForSeconds(secs);
         displayManager.RpcResultOverlaySetActive(true);
+        
+            
     }
 
     private IEnumerator WaitAndChangePhase()


### PR DESCRIPTION
Fixed Timeout to only start after at least two players pressed the ready button.